### PR TITLE
Remove dfischer:faker in favor of npm package.

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -10,13 +10,11 @@ boilerplate-generator@1.0.9
 caching-compiler@1.1.7_1
 callback-hook@1.0.9
 check@1.2.3
-coffeescript@1.2.4
 ddp@1.2.5
 ddp-client@1.3.1
 ddp-common@1.2.6
 ddp-server@1.3.10
 deps@1.0.12
-dfischer:faker@1.0.8
 diff-sequence@1.0.6
 ecmascript@0.5.8_1
 ecmascript-runtime@0.3.14_1
@@ -36,7 +34,7 @@ logging@1.1.15_1
 mdg:animations@0.2.3
 mdg:borealis@0.2.5
 mdg:buttons@0.2.5
-mdg:callout@0.2.4
+mdg:callout@0.2.5
 mdg:chromatic@0.2.7
 mdg:chromatic-api@0.2.4
 mdg:chromatic-explorer@0.2.8
@@ -50,7 +48,7 @@ mdg:loading-spinner@0.2.5
 mdg:outlines@0.2.3
 mdg:overlays@0.2.8
 mdg:react-meteor-app@0.2.5
-mdg:sortable@0.2.7
+mdg:sortable@0.2.8
 mdg:tooltips@0.2.5
 mdg:utils@0.2.3
 mdg:validation-error@0.5.1

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "autosize": "3.0.15",
     "classnames": "^2.2.5",
+    "faker": "^3.1.0",
     "react": "^15.2.1",
     "react-addons-create-fragment": "^15.2.1",
     "react-addons-css-transition-group": "^15.2.1",

--- a/packages/callout/package.js
+++ b/packages/callout/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mdg:callout',
-  version: '0.2.4',
+  version: '0.2.5',
   summary: 'an important thing at the top of the screen',
   git: 'https://github.com/meteor/chromatic',
   documentation: null
@@ -9,7 +9,6 @@ Package.describe({
 Package.onUse(function(api) {
   api.versionsFrom('1.3');
   api.use([
-    'dfischer:faker@1.0.8',
     'ecmascript',
     'less',
     'mdg:borealis@0.2.5',

--- a/packages/sortable/SortableTableExample.jsx
+++ b/packages/sortable/SortableTableExample.jsx
@@ -1,5 +1,5 @@
 /* global SortableTableExample:true */
-/* global Sortable faker */
+/* global Sortable */
 
 import React from 'react';
 
@@ -8,6 +8,7 @@ const {Chromatic} = Package['mdg:chromatic-api'] || {};
 SortableTableExample = React.createClass({
   componentWillMount() {
     this.sortableData = new Mongo.Collection(null);
+    const faker = require("faker");
     _.times(5, () => {
       this.sortableData.insert({
         name: faker.name.findName(),

--- a/packages/sortable/package.js
+++ b/packages/sortable/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mdg:sortable',
-  version: '0.2.7',
+  version: '0.2.8',
   summary: 'Components to create sortable things',
   git: 'https://github.com/meteor/chromatic',
   documentation: null
@@ -12,7 +12,6 @@ Package.onUse(function(api) {
     'ecmascript',
     'mdg:borealis@0.2.5',
     'mdg:chromatic@0.2.6',
-    'dfischer:faker@1.0.8'
   ], 'client');
   api.addFiles(['Sortable.jsx', 'SortableTableExample.jsx'], 'client');
   api.export('Sortable', 'client');


### PR DESCRIPTION
The `dfischer:faker` package always loads a large amount of mock data during app startup, on both the client and the server, even in production. This change saves at least 200ms of page load time when `faker` is not needed.

Any app that uses `mdg:callout` or `mdg:sortable` will have to pay this cost, even if those packages do not make any use of `dfischer:faker`, and even if the app does not otherwise depend on `dfischer:faker`.

Instead, it should be up to the app to install `faker` as an `npm` package, and it should be `require`d only when needed.