### PR TITLE
Load tooltip plugin and styles on demand

### DIFF
--- a/packages/tooltips/WithTooltip.jsx
+++ b/packages/tooltips/WithTooltip.jsx
@@ -88,6 +88,9 @@ WithTooltip = React.createClass({
     };
   },
   attach() {
+    require("./jquery.qtip.js");
+    require("./WithTooltip.less");
+
     const options = _.extend(MODES[this.props.mode], this.props.options, {
       content: { text: this.drawTooltip()}
     });

--- a/packages/tooltips/package.js
+++ b/packages/tooltips/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mdg:tooltips',
-  version: '0.2.5',
+  version: '0.2.6',
   summary: 'Basic tooltip wrapper for elements',
   git: 'https://github.com/meteor/chromatic',
   documentation: null
@@ -15,11 +15,11 @@ Package.onUse(function(api) {
     'mdg:borealis@0.2.5',
     'mdg:chromatic-api@0.2.4'
   ], 'client');
+
   api.addFiles([
-    'jquery.qtip.js',
-    'jquery.qtip.import.less',
     'WithTooltip.jsx',
-    'WithTooltip.less',
-    'TooltipStyleguide.jsx'], 'client');
+    'TooltipStyleguide.jsx'
+  ], 'client');
+
   api.export('WithTooltip', 'client');
 });


### PR DESCRIPTION
With these changes, neither the implementation of the qtip plugin nor the associated styles will be evaluated until the first time a `WithTooltip` component is attached to the DOM.