### PR TITLE
Support FlowRouter.route({getComponent}) for lazy component imports

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -43,7 +43,7 @@ mdg:chromatic-explorer@0.2.8
 mdg:code-block@0.2.5
 mdg:color-grid@0.2.4
 mdg:date-components@0.2.4
-mdg:flow-router-extensions@0.2.7
+mdg:flow-router-extensions@0.2.8
 mdg:form-components@0.2.6
 mdg:list@0.2.12
 mdg:loading-spinner@0.2.5

--- a/packages/flow-router-extensions/flow-router-extensions.js
+++ b/packages/flow-router-extensions/flow-router-extensions.js
@@ -16,8 +16,15 @@ FlowRouter.getRouteHandler = function() {
   // See https://github.com/meteor/galaxy-server/issues/367 for instance.
   FlowRouter.getParam('foobar');
 
-  var current = FlowRouter.current();
-  return current.route.options.component;
+  const current = FlowRouter.current();
+  const options = current.route.options;
+
+  if (typeof options.getComponent === "function") {
+    // Allow the component to be loaded lazily.
+    options.component = options.getComponent();
+  }
+
+  return options.component;
 };
 
 const oldRoute = FlowRouter.route.bind(FlowRouter);

--- a/packages/flow-router-extensions/package.js
+++ b/packages/flow-router-extensions/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mdg:flow-router-extensions',
-  version: '0.2.7',
+  version: '0.2.8',
   summary: 'Update flow router to use a pattern that is more contained',
   git: 'https://github.com/meteor/chromatic',
   documentation: null


### PR DESCRIPTION
This allows the importing of a component class to be deferred until a route is actually about to be fired, and will be very useful for optimizing [`optics/webapp/client/routes.js`](https://github.com/mdg-private/optics-frontend/blob/devel/webapp/client/routes.js).