### PR TITLE
Support OverlayController.route(name, getter) for lazy imports

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -48,7 +48,7 @@ mdg:form-components@0.2.6
 mdg:list@0.2.12
 mdg:loading-spinner@0.2.5
 mdg:outlines@0.2.3
-mdg:overlays@0.2.7
+mdg:overlays@0.2.8
 mdg:react-meteor-app@0.2.5
 mdg:sortable@0.2.7
 mdg:tooltips@0.2.5

--- a/packages/overlays/package.js
+++ b/packages/overlays/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mdg:overlays',
-  version: '0.2.7',
+  version: '0.2.8',
   summary: 'Overlay layout and mechanism to drive overlays',
   git: 'https://github.com/meteor/chromatic',
   documentation: null


### PR DESCRIPTION
Similar to #23, this change allows the `OverlayController` to defer importing components until necessary, which often means they don't need to be imported during page load. Also useful for optimizing [`optics/webapp/client/routes.js`](https://github.com/mdg-private/optics-frontend/blob/devel/webapp/client/routes.js).