### PR TITLE
Only return overlay component if route getter defined.

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -46,7 +46,7 @@ mdg:form-components@0.2.6
 mdg:list@0.2.12
 mdg:loading-spinner@0.2.5
 mdg:outlines@0.2.3
-mdg:overlays@0.2.8
+mdg:overlays@0.2.9
 mdg:react-meteor-app@0.2.7
 mdg:sortable@0.2.8
 mdg:tooltips@0.2.6

--- a/packages/overlays/OverlayController.js
+++ b/packages/overlays/OverlayController.js
@@ -48,9 +48,11 @@ class OverlayRouter {
   getComponent() {
     const name = FlowRouter.getQueryParam('overlay');
     const getter = this._routeGetters[name];
-    const component = getter();
-    assert.strictEqual(component.displayName, name);
-    return component;
+    if (getter) {
+      const component = getter();
+      assert.strictEqual(component.displayName, name);
+      return component;
+    }
   }
 }
 

--- a/packages/overlays/package.js
+++ b/packages/overlays/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mdg:overlays',
-  version: '0.2.8',
+  version: '0.2.9',
   summary: 'Overlay layout and mechanism to drive overlays',
   git: 'https://github.com/meteor/chromatic',
   documentation: null


### PR DESCRIPTION
Previous behavior (before 84f7ab278d368507cbde34926335f42c41c1ae19) allowed `OverlayController#getComponent` to return `undefined` if `FlowRouter.getQueryParam("overlay")` returned an unknown name, so we should probably still allow that.

cc @daniman 