### PR TITLE
Support for dynamic imports

### DIFF
--- a/packages/chromatic-api/chromatic-api.js
+++ b/packages/chromatic-api/chromatic-api.js
@@ -1,5 +1,6 @@
 /* global Chromatic:true */
 import React from 'react';
+import {ReactiveDict} from 'meteor/reactive-dict';
 
 /**
  * Chromatic API
@@ -85,26 +86,27 @@ export const Chromatic = {
   addEntry(entry) {
     check(entry, Chromatic.Entry);
     Chromatic._entries[entry.name] = entry;
+    this._entriesDict.set(entry.name, true);
   },
 
   /**
-   * Gets a styleguide entry
+   * Gets a styleguide entry (reactive)
    * @param {String} name - the name of the entry
    * @returns {Object} entry - an instance of Chromatic.Entry
    */
   entry(name) {
     check(name, String);
-    return Chromatic._entries[name];
+    return this._entriesDict.get(name) ? Chromatic._entries[name] : null;
   },
 
   /**
-   * Returns the list of non-page styleguide entries
+   * Returns the list of non-page styleguide entries (reactive)
    * @returns {[Chromatic.Entry]}
    */
   allEntries: function() {
+    this._entriesDict.allDeps.depend();
     const entries = _.values(Chromatic._entries);
-    const componentEntries = _.filter(entries, (entry) => !entry.isPage);
-    return _.sortBy(componentEntries, (entry) => entry.name);
+    return _.filter(entries, (entry) => !entry.isPage);
   },
 
   /**
@@ -120,4 +122,5 @@ export const Chromatic = {
    * A dict that contains the list of styleguide entries
    */
   _entries: {},
+  _entriesDict: new ReactiveDict()
 };

--- a/packages/chromatic-api/package.js
+++ b/packages/chromatic-api/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mdg:chromatic-api',
-  version: '0.2.4',
+  version: '0.3.0',
   summary: 'chromatic dev include',
   git: 'https://github.com/meteor/chromatic',
   debugOnly: true,

--- a/packages/chromatic-explorer/ChromaticExplorer.js
+++ b/packages/chromatic-explorer/ChromaticExplorer.js
@@ -14,29 +14,39 @@ ChromaticExplorer = {
 
   configure: function(options) {
     check(options, {
-      basePath: String
+      basePath: String,
+      onRouteEnter: Match.Optional(Function)
+    });
+
+    const chromaticRoutes = FlowRouter.group({
+      prefix: options.basePath,
+      triggersEnter: [(context, redirect) => {
+        if (options.onRouteEnter) {
+          options.onRouteEnter(context, redirect);
+        }
+      }]
     });
 
     // add routes for any app-defined pages
     const pages = Chromatic.allPages();
     pages.forEach(page => {
-      FlowRouter.route(`${options.basePath}/${page.name}/:entryName?`, {
+      chromaticRoutes.route(`/${page.name}/:entryName?`, {
         name: `chromatic-${page.name}-styleguide`,
         component: page.component
       });
     });
     //  add iframe routes for each component
-    FlowRouter.route(`${options.basePath}/_component/:entryName?/:specName?`, {
+    chromaticRoutes.route('/_component/:entryName?/:specName?', {
       name: 'chromatic-component-iframe',
       component: ComponentSpec
     });
     //  add iframe routes for 'all' spec option for each component
-    FlowRouter.route(`${options.basePath}/_component/:entryName?/all`, {
+    chromaticRoutes.route('/_component/:entryName?/all', {
       name: 'chromatic-component-iframe',
       component: ComponentSpec
     });
 
-    FlowRouter.route(options.basePath, {
+    chromaticRoutes.route('/', {
       action: () => {
         FlowRouter.go(`chromatic-${pages[0].name}-styleguide`);
       }

--- a/packages/chromatic-explorer/ComponentSpec.jsx
+++ b/packages/chromatic-explorer/ComponentSpec.jsx
@@ -1,7 +1,6 @@
 /* global ComponentSpec:true */
 /* global StyleguideSpec FlowRouter */
 
-import classnames from 'classnames';
 import React from 'react';
 import {ReactMeteorData} from 'meteor/react-meteor-data';
 const {Chromatic} = Package['mdg:chromatic-api'] || {};
@@ -9,18 +8,24 @@ const {Chromatic} = Package['mdg:chromatic-api'] || {};
 ComponentSpec = React.createClass({
   mixins: [ReactMeteorData],
   getMeteorData() {
+    const entryName = FlowRouter.getParam('entryName');
+    const specName = FlowRouter.getParam('specName');
+    const entry = Chromatic.entry(entryName);
     return {
-      entryName: FlowRouter.getParam('entryName'),
-      specName: FlowRouter.getParam('specName')
+      entry,
+      specName
     };
   },
   componentWillMount() {
     $('body').addClass('styleguide-white fill-iframe');
   },
   render() {
-    const {entryName, specName} = this.data;
-    const entry = Chromatic.entry(entryName);
+    const {entry, specName} = this.data;
     let specNames = [];
+
+    if (!entry) {
+      return null;
+    }
 
     const makeSpec = (name) => {
       return (
@@ -28,7 +33,7 @@ ComponentSpec = React.createClass({
           <StyleguideSpec entry={entry} specName={name}/>
         </div>
       );
-    }
+    };
 
     if (specName === 'all') {
       specNames = entry.specs.map(s => s.name);

--- a/packages/chromatic-explorer/ComponentsPage.jsx
+++ b/packages/chromatic-explorer/ComponentsPage.jsx
@@ -9,6 +9,7 @@ ComponentsPage = React.createClass({
   mixins: [ReactMeteorData],
   getMeteorData() {
     return {
+      entries: Chromatic.allEntries(),
       entryName: FlowRouter.getParam('entryName'),
       filterParam: FlowRouter.getQueryParam('filter')
     };
@@ -50,7 +51,7 @@ ComponentsPage = React.createClass({
     this.updateRecents(evt.target.title);
   },
   render() {
-    const {entryName, filterParam} = this.data;
+    const {entries, entryName, filterParam} = this.data;
     const {recents, showRecents, filterState} = this.state;
     const filterString = filterParam || filterState;
 
@@ -60,9 +61,15 @@ ComponentsPage = React.createClass({
 
     return (
       <ChromaticLayout showSidebar={true} sidebar={
-          <ComponentsPageSidebar recents={recents} filter={filterString} showRecents={showRecents}
-            onFilterInput={this.onFilterInput} onFilterSubmit={this.onFilterSubmit}
-            onEntryClick={this.onEntryClick}/>} >
+          <ComponentsPageSidebar
+            entries={entries}
+            recents={recents}
+            filter={filterString}
+            showRecents={showRecents}
+            onFilterInput={this.onFilterInput}
+            onFilterSubmit={this.onFilterSubmit}
+            onEntryClick={this.onEntryClick}/>}
+          >
         <div className="styleguide-content">
           <StyleguideReadme/>
         </div>

--- a/packages/chromatic-explorer/ComponentsPageSidebar.jsx
+++ b/packages/chromatic-explorer/ComponentsPageSidebar.jsx
@@ -2,6 +2,7 @@
 /* global FlowRouter PageToggleButton Form */
 
 import React from 'react';
+import { _ } from 'meteor/underscore';
 const {Chromatic} = Package['mdg:chromatic-api'] || {};
 
 ComponentsPageSidebar = React.createClass({
@@ -9,19 +10,19 @@ ComponentsPageSidebar = React.createClass({
     onFilterInput: React.PropTypes.func.isRequired,
     onFilterSubmit: React.PropTypes.func.isRequired,
     onEntryClick: React.PropTypes.func.isRequired,
+    entries: React.PropTypes.array.isRequired,
     recents: React.PropTypes.array.isRequired,
     showRecents: React.PropTypes.bool,
     filter: React.PropTypes.string
   },
   render() {
-    const {onFilterInput, onFilterSubmit, recents, filter, showRecents} = this.props;
+    const {onFilterInput, onFilterSubmit, recents, entries, filter, showRecents} = this.props;
 
     //  TODO: use better regex
     const filterRE = new RegExp(filter, 'i');
-    const entries = Chromatic.allEntries();
-    const entryLinks = entries.filter(e => {
+    const entryLinks = _.sortBy(entries.filter(e => {
       return filterRE.test(e.name);
-    }).map(e => {
+    }), 'name').map(e => {
       const n = e.name;
       return (
         <a href={FlowRouter.path('chromatic-components-styleguide', {entryName: n})}

--- a/packages/chromatic-explorer/package.js
+++ b/packages/chromatic-explorer/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mdg:chromatic-explorer',
-  version: '0.2.9',
+  version: '0.3.0',
   summary: 'chromatic component explorer',
   git: 'https://github.com/meteor/chromatic',
   debugOnly: true,
@@ -17,7 +17,7 @@ Package.onUse(function(api) {
     'react-meteor-data@0.2.9',
     'kadira:flow-router@2.4.0',
     'mdg:flow-router-extensions@0.2.3',
-    'mdg:chromatic-api@0.2.4',
+    'mdg:chromatic-api@0.3.0',
     'mdg:form-components@0.2.7',
     'mdg:color-grid@0.2.3',
     'mdg:outlines@0.2.3'

--- a/packages/chromatic/package.js
+++ b/packages/chromatic/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mdg:chromatic',
-  version: '0.2.7',
+  version: '0.3.0',
   summary: 'a visualizer for react components',
   git: 'https://github.com/meteor/chromatic',
   documentation: null
@@ -11,8 +11,8 @@ Package.onUse(function(api) {
 
   api.use([
     'ecmascript',
-    'mdg:chromatic-api@0.2.4',
-    'mdg:chromatic-explorer@0.2.8'
+    'mdg:chromatic-api@0.3.0',
+    'mdg:chromatic-explorer@0.3.0'
   ], 'client');
 
   api.mainModule('main.js', 'client');


### PR DESCRIPTION
Helps provide support for dynamic imports in applications.
1. Component entries can now be added dynamically and show up in the component list.
2. You can now give Chromatic a callback to fire when it loads any of its routes, allowing you to run a dynamic import at this time for loading specs.