### PR TITLE
Only depend on the English locale of the `faker` npm.

### DIFF
--- a/packages/sortable/SortableTableExample.jsx
+++ b/packages/sortable/SortableTableExample.jsx
@@ -8,7 +8,7 @@ const {Chromatic} = Package['mdg:chromatic-api'] || {};
 SortableTableExample = React.createClass({
   componentWillMount() {
     this.sortableData = new Mongo.Collection(null);
-    const faker = require("faker");
+    const faker = require("faker/locale/en");
     _.times(5, () => {
       this.sortableData.insert({
         name: faker.name.findName(),

--- a/packages/sortable/package.js
+++ b/packages/sortable/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mdg:sortable',
-  version: '0.2.9',
+  version: '0.2.10',
   summary: 'Components to create sortable things',
   git: 'https://github.com/meteor/chromatic',
   documentation: null

--- a/packages/sortable/package.js
+++ b/packages/sortable/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mdg:sortable',
-  version: '0.2.8',
+  version: '0.2.9',
   summary: 'Components to create sortable things',
   git: 'https://github.com/meteor/chromatic',
   documentation: null


### PR DESCRIPTION
This removes a lot of the other languages which we're not specifically testing in any way (and English is being used by default for what we are using).

I've bumped the version, but have not published as I'm not sure what exactly would depend on this downstream that I should test – though this change should absolutely be harmless, I'm aware of some implementations which are not currently using the latest version.