### PR TITLE
Redirect to login page after logout

### DIFF
--- a/packages/borealis/package.js
+++ b/packages/borealis/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mdg:borealis',
-  version: '0.2.21',
+  version: '0.2.22',
   summary: 'a style system',
   documentation: null,
 })

--- a/packages/borealis/react-components/NavigationBar.js
+++ b/packages/borealis/react-components/NavigationBar.js
@@ -210,7 +210,7 @@ class NavigationBarComponent extends React.Component {
           const subSubItemOpenId = `${subitem.label}-thirdlevel`;
           const logoutFunction = () => {
             Meteor.logout();
-            window.location.href = 'https://www.meteor.com';
+            window.location.href = 'https://cloud.meteor.com';
           };
           const logoutOnClick = subitem.label === SPECIAL_ITEMS.LOG_OUT
               ? logoutFunction


### PR DESCRIPTION
Instead of redirecting to https://www.meteor.com after logging out, we redirect to the login page, https://cloud.meteor.com